### PR TITLE
WIP - Change to default datetime widget

### DIFF
--- a/views/harvestlogbook.ejs
+++ b/views/harvestlogbook.ejs
@@ -18,8 +18,6 @@
     <h3>HARVEST LOGBOOK</h3>
     <div>
       <a class="btn btn-primary btn-sm" onclick="ShowModal(this, 'add', 'Add Harvest Entry','addCSS')">Add New Harvest Entry</a>
-<!--      <a class="btn btn-primary btn-sm enableBlockchainButton" >Enable Blockchain Wallet</a>-->
-<!--      <p>Connected Account: <span class="showAccount"></span></p>-->
     </div>
     
     <% include ./partials/notificationbar %>
@@ -333,20 +331,14 @@
                 <div class="form-group">
                     <label for="viewmodal_harvest_timestamp">Harvest Timestamp</label>
                     <div class="input-group form_datetime" id="viewmodal_harvest_timestamp_datetimepicker" data-target-input="viewmodal_harvest_timestamp">
-                        <input type="text" class="form-control datetimepicker-input" id="viewmodal_harvest_timestamp" name="viewmodal_harvest_timestamp" placeholder="Actual time of Harvest in the field (Harvest Timestamp)" data-target="#viewmodal_harvest_timestamp"/>
-                        <span class="input-group-addon" data-target="#viewmodal_harvest_timestamp" data-toggle="datetimepicker">
-                            <span class="glyphicon glyphicon-calendar"></span>
-                        </span>
+                        <input type="datetime-local" class="form-control" id="viewmodal_harvest_timestamp" name="viewmodal_harvest_timestamp" placeholder="Actual time of Harvest in the field (Harvest Timestamp)" data-target="#viewmodal_harvest_timestamp"/>
                     </div>
                 </div>
 
                 <div class="form-group" id="viewmodal_harvest_capturetimeDiv">
                   <label for="viewmodal_harvest_capturetime">Harvest Data Capture Time</label>
                   <div class="input-group form_datetime" id="viewmodal_harvest_capturetime_datetimepicker" data-target-input="viewmodal_harvest_capturetime">
-                      <input type="text" class="form-control datetimepicker-input" id="viewmodal_harvest_capturetime" name="viewmodal_harvest_capturetime" placeholder="Harvest Data Capture Time" data-target="#viewmodal_harvest_capturetime"/>
-                      <span class="input-group-addon" data-target="#viewmodal_harvest_capturetime" data-toggle="datetimepicker">
-                          <span class="glyphicon glyphicon-calendar"></span>
-                      </span>
+                      <input type="datetime-local" class="form-control" id="viewmodal_harvest_capturetime" name="viewmodal_harvest_capturetime" placeholder="Harvest Data Capture Time" data-target="#viewmodal_harvest_capturetime"/>
                   </div>
                 </div>
 
@@ -397,11 +389,6 @@
                   <label for="viewmodal_harvest_blockchainhashdata">Blockchain Hash Data</label>
                   <input type="text" name="viewmodal_harvest_blockchainhashdata" class="form-control" id="viewmodal_harvest_blockchainhashdata" placeholder="Blockchain Hash Data">
                 </div>
-
-                <!-- <div class="form-group">
-                  <label for="viewmodal_supplierproduce">Supplier Produce</label>
-                  <input type="text" name="viewmodal_supplierproduce" class="form-control" id="viewmodal_supplierproduce" placeholder="Supplier Produce">
-                </div> -->
                 
                 <div class="form-group" id="viewmodal_harvest_bool_added_to_blockchainDiv">
                   <label for="viewmodal_harvest_bool_added_to_blockchain">Harvest Added to Blockchain - Yes / No</label>
@@ -411,10 +398,7 @@
                 <div class="form-group" id="viewmodal_harvest_added_to_blockchain_dateDiv">
                   <label for="viewmodal_harvest_added_to_blockchain_date">Harvest Added to Blockchain Datetime</label>
                   <div class="input-group form_datetime" id="viewmodal_harvest_added_to_blockchain_date_datetimepicker" data-target-input="viewmodal_harvest_added_to_blockchain_date">
-                      <input type="text" class="form-control datetimepicker-input" id="viewmodal_harvest_added_to_blockchain_date" name="viewmodal_harvest_added_to_blockchain_date" placeholder="Harvest Added to Blockchain Datetime" data-target="#viewmodal_harvest_added_to_blockchain_date"/>
-                      <span class="input-group-addon" data-target="#viewmodal_harvest_added_to_blockchain_date" data-toggle="datetimepicker">
-                          <span class="glyphicon glyphicon-calendar"></span>
-                      </span>
+                      <input type="datetime-local" class="form-control" id="viewmodal_harvest_added_to_blockchain_date" name="viewmodal_harvest_added_to_blockchain_date" placeholder="Harvest Added to Blockchain Datetime" data-target="#viewmodal_harvest_added_to_blockchain_date"/>
                   </div>
                 </div>
 
@@ -436,36 +420,21 @@
                 <div class="form-group" id="viewmodal_logdatetimeDiv">
                   <label for="viewmodal_logdatetime">Log Datetime</label>
                   <div class="input-group form_datetime" id="viewmodal_logdatetime_datetimepicker" data-target-input="viewmodal_logdatetime">
-                      <input type="text" class="form-control datetimepicker-input" id="viewmodal_logdatetime" name="viewmodal_logdatetime" placeholder="Log Datetime" data-target="#viewmodal_logdatetime"/>
-                      <span class="input-group-addon" data-target="#viewmodal_logdatetime" id="viewmodal_logdatetime_calendar" data-toggle="datetimepicker">
-                          <span class="glyphicon glyphicon-calendar" id="viewmodal_logdatetime_calendar_icon"></span>
-                      </span>
+                      <input type="datetime-local" class="form-control" id="viewmodal_logdatetime" name="viewmodal_logdatetime" placeholder="Log Datetime" data-target="#viewmodal_logdatetime"/>
                   </div>
                 </div>
             
                 <div class="form-group" id="viewmodal_lastmodifieddatetimeDiv">
                   <label for="viewmodal_lastmodifieddatetime">Last Modified Datetime</label>
                   <div class="input-group form_datetime" id="viewmodal_lastmodifieddatetime_datetimepicker" data-target-input="viewmodal_lastmodifieddatetime">
-                      <input type="text" class="form-control datetimepicker-input" id="viewmodal_lastmodifieddatetime" name="viewmodal_lastmodifieddatetime" placeholder="Last Modified Datetime" data-target="#viewmodal_lastmodifieddatetime"/>
-                      <span class="input-group-addon" data-target="#viewmodal_lastmodifieddatetime" data-toggle="datetimepicker">
-                          <span class="glyphicon glyphicon-calendar"></span>
-                      </span>
+                      <input type="datetime-local" class="form-control" id="viewmodal_lastmodifieddatetime" name="viewmodal_lastmodifieddatetime" placeholder="Last Modified Datetime" data-target="#viewmodal_lastmodifieddatetime"/>
                   </div>
                 </div>
 
                 <div class="form-group" id="viewmodal_harvest_logidDiv">
                   <label for="viewmodal_harvest_logid">Harvest ID</label>
                   <input type="text" name="viewmodal_harvest_logid" class="form-control" id="viewmodal_harvest_logid" placeholder="Harvest ID">
-                </div> 
-                
-              <!-- <div class="form-group">
-                <div class="input-group date" id="datetimepicker1" data-target-input="#inputdatetimepicker1">
-                    <input type="text" class="form-control datetimepicker-input" placeholder="Last Modified Datetime"  id="inputdatetimepicker1" data-target="#inputdatetimepicker1"/>
-                    <span class="input-group-addon" data-target="#inputdatetimepicker1" data-toggle="datetimepicker">
-                        <span class="glyphicon glyphicon-calendar"></span>
-                    </span>
                 </div>
-            </div> -->
 
                 <div class="form-check" id="harvestCheckDiv">
                   <input type="checkbox" class="form-check-input" id="harvestCheck" required>
@@ -504,34 +473,13 @@
   <script src="/js/sha256.min.js"></script><!-- Blockchain -->
 
   <script type="text/javascript">
-    $(function () {
-                    $('#datetimepicker1').datetimepicker();
-                });
-
-    $(function () {
-      $('.form_datetime').datetimepicker();
-     /*    $('.form_datetime').datetimepicker({
-          weekStart: 1,
-          todayBtn:  1,
-      autoclose: 1,
-      todayHighlight: 1,
-      startView: 2,
-      forceParse: 0,
-          showMeridian: 1
-      }); */
-    });
-  </script>
-
-  <script type="text/javascript">
     function addToBlockchain(obj_identifier) {
       var harvestLogid = $(obj_identifier).data('harvest_logid');
       var harvestAddBlockchainBtnId = "#harvest_add_blockchain_" + harvestLogid;
 
-      //$(harvestAddBlockchainBtnId).click(function (event) {
-        //event.preventDefault();
-
         // add spinner and disable button
         $(harvestAddBlockchainBtnId).addClass('disabled');
+
         // add spinner to button
         $(harvestAddBlockchainBtnId).html(
                 `<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Adding to Blockchain...`
@@ -670,7 +618,24 @@
 
       console.log("harvest_logid - " + harvest_logid);
       // console.log("supplierproduce - " + supplierproduce);
-      // console.log("harvest_TimeStamp - " + harvest_TimeStamp);
+
+      console.log("harvest_timestamp - " + harvest_timestamp);
+      // harvest_timestamp - Wed May 25 2022 13:49:00 GMT+0200 (South Africa Standard Time)
+
+      //NB - this is the format the datetime-local HTML input will accept i.e. something like an ISOString without the Z
+      // var harvest_timestamp_iso = "2014-01-02T11:42:13.510";
+
+      //var harvest_timestamp_iso = new Date(harvest_timestamp).toISOString();
+      // 2022-05-25T11:49:00.000Z The Z on the end means UTC
+
+      var harvest_timestamp_adjusted = moment(new Date(harvest_timestamp)).format("YYYY-MM-DDTHH:mm")
+      console.log("harvest_timestamp_adjusted - " +  harvest_timestamp_adjusted);
+
+      harvest_capturetime = moment(new Date(harvest_capturetime)).format("YYYY-MM-DDTHH:mm");
+      harvest_added_to_blockchain_date = moment(new Date(harvest_added_to_blockchain_date)).format("YYYY-MM-DDTHH:mm");
+      logdatetime = moment(new Date(logdatetime)).format("YYYY-MM-DDTHH:mm");
+      lastmodifieddatetime = moment(new Date(lastmodifieddatetime)).format("YYYY-MM-DDTHH:mm");
+
       // console.log("harvest_supplierName - " + harvest_supplierName);
       // console.log("harvest_photohash - " + harvest_photohash);
       //console.log("harvest_photoimage - " + harvest_photoimage);
@@ -722,7 +687,7 @@
       //$('#viewmodal_harvest_photohash').val(harvest_photohash);            
       $('#viewmodal_harvest_photoimage').attr("src", harvest_photoimage);
 
-      $('#viewmodal_harvest_timestamp').val(harvest_timestamp);
+      $('#viewmodal_harvest_timestamp').val(harvest_timestamp_adjusted);
       $('#viewmodal_harvest_capturetime').val(harvest_capturetime);
       $('#viewmodal_harvest_description').val(harvest_description);
       $('#viewmodal_harvest_geolocation').val(harvest_geolocation);
@@ -809,7 +774,6 @@
     }
     else if (action==='view'){
       $("#modalBodyContainer :input").attr("disabled", true); //make fields read-only
-      // $('#form1 input').attr('readonly', 'readonly');    
 
       //SHOW DIVS
       //System populated:


### PR DESCRIPTION
change input type for datetime fields from `text` to `datetime-local` and drop datepicker from class i.e. `class="form-control datetimepicker-input"` to `class="form-control"`

Remove bootstrap datetimepicker custom JS `$(function () {
                    $('#datetimepicker1').datetimepicker();
                });`

Convert datetime objects from DB to `format("YYYY-MM-DDTHH:mm");` e.g. ` var harvest_timestamp_adjusted = moment(new Date(harvest_timestamp)).format("YYYY-MM-DDTHH:mm")`
     ` console.log("harvest_timestamp_adjusted - " +  harvest_timestamp_adjusted);`