### PR TITLE
Add postgres support

### DIFF
--- a/migrations/20220604131504-remove-primary-index.js
+++ b/migrations/20220604131504-remove-primary-index.js
@@ -1,0 +1,35 @@
+'use strict';
+/*
+$npx sequelize-cli migration:create --name remove-primary-index
+$npm run build-dev
+*/
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    // logic for transforming into the new state
+    await queryInterface.removeIndex('foodprint_config', 'PRIMARY')
+        .then(queryInterface.removeIndex('foodprint_harvest', 'PRIMARY'))
+        .then(queryInterface.removeIndex('foodprint_produce', 'PRIMARY'))
+        .then(queryInterface.removeIndex('foodprint_produce_price', 'PRIMARY'))
+        .then(queryInterface.removeIndex('foodprint_qrcount', 'PRIMARY'))
+        .then(queryInterface.removeIndex('foodprint_storage', 'PRIMARY'))
+        .then(queryInterface.removeIndex('foodprint_subscription', 'PRIMARY'))
+        .then(queryInterface.removeIndex('foodprint_weeklyview', 'PRIMARY'))
+        .then(queryInterface.removeIndex('market_subscription', 'PRIMARY'))
+        .then(queryInterface.removeIndex('user', 'PRIMARY'));
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    // logic for reverting the changes
+    await queryInterface.addIndex('foodprint_config', 'PRIMARY')
+        .then(queryInterface.addIndex('foodprint_harvest', 'PRIMARY'))
+        .then(queryInterface.addIndex('foodprint_produce', 'PRIMARY'))
+        .then(queryInterface.addIndex('foodprint_produce_price', 'PRIMARY'))
+        .then(queryInterface.addIndex('foodprint_qrcount', 'PRIMARY'))
+        .then(queryInterface.addIndex('foodprint_storage', 'PRIMARY'))
+        .then(queryInterface.addIndex('foodprint_subscription', 'PRIMARY'))
+        .then(queryInterface.addIndex('foodprint_weeklyview', 'PRIMARY'))
+        .then(queryInterface.addIndex('market_subscription', 'PRIMARY'))
+        .then(queryInterface.addIndex('user', 'PRIMARY'));
+  }
+};

--- a/models/foodprint_config.js
+++ b/models/foodprint_config.js
@@ -36,7 +36,7 @@ module.exports = function (sequelize, DataTypes) {
       timestamps: false,
       indexes: [
         {
-          name: 'PRIMARY',
+          name: 'foodprint_config_PRIMARY',
           unique: true,
           using: 'BTREE',
           fields: [{ name: 'pk' }],

--- a/models/foodprint_harvest.js
+++ b/models/foodprint_harvest.js
@@ -124,7 +124,7 @@ module.exports = function (sequelize, DataTypes) {
       timestamps: false,
       indexes: [
         {
-          name: 'PRIMARY',
+          name: 'foodprint_harvest_PRIMARY',
           unique: true,
           using: 'BTREE',
           fields: [{ name: 'pk' }],

--- a/models/foodprint_produce.js
+++ b/models/foodprint_produce.js
@@ -24,7 +24,7 @@ module.exports = function (sequelize, DataTypes) {
       timestamps: false,
       indexes: [
         {
-          name: 'PRIMARY',
+          name: 'foodprint_produce_PRIMARY',
           unique: true,
           using: 'BTREE',
           fields: [{ name: 'pk' }],

--- a/models/foodprint_produce_price.js
+++ b/models/foodprint_produce_price.js
@@ -32,7 +32,7 @@ module.exports = function (sequelize, DataTypes) {
       timestamps: false,
       indexes: [
         {
-          name: 'PRIMARY',
+          name: 'foodprint_produce_price_PRIMARY',
           unique: true,
           using: 'BTREE',
           fields: [{ name: 'pk' }],

--- a/models/foodprint_qrcount.js
+++ b/models/foodprint_qrcount.js
@@ -48,7 +48,7 @@ module.exports = function (sequelize, DataTypes) {
       timestamps: false,
       indexes: [
         {
-          name: 'PRIMARY',
+          name: 'foodprint_qrcount_PRIMARY',
           unique: true,
           using: 'BTREE',
           fields: [{ name: 'pk' }],

--- a/models/foodprint_storage.js
+++ b/models/foodprint_storage.js
@@ -108,7 +108,7 @@ module.exports = function (sequelize, DataTypes) {
       timestamps: false,
       indexes: [
         {
-          name: 'PRIMARY',
+          name: 'foodprint_storage_PRIMARY',
           unique: true,
           using: 'BTREE',
           fields: [{ name: 'pk' }],

--- a/models/foodprint_subscription.js
+++ b/models/foodprint_subscription.js
@@ -32,7 +32,7 @@ module.exports = function (sequelize, DataTypes) {
       timestamps: false,
       indexes: [
         {
-          name: 'PRIMARY',
+          name: 'foodprint_subscription_PRIMARY',
           unique: true,
           using: 'BTREE',
           fields: [{ name: 'pk' }],

--- a/models/foodprint_weeklyview.js
+++ b/models/foodprint_weeklyview.js
@@ -192,7 +192,7 @@ module.exports = function (sequelize, DataTypes) {
       timestamps: false,
       indexes: [
         {
-          name: 'PRIMARY',
+          name: 'foodprint_weeklyview_PRIMARY',
           unique: true,
           using: 'BTREE',
           fields: [{ name: 'pk' }],

--- a/models/market_subscription.js
+++ b/models/market_subscription.js
@@ -36,7 +36,7 @@ module.exports = function (sequelize, DataTypes) {
       timestamps: false,
       indexes: [
         {
-          name: 'PRIMARY',
+          name: 'market_subscription_PRIMARY',
           unique: true,
           using: 'BTREE',
           fields: [{ name: 'pk' }],

--- a/models/user.js
+++ b/models/user.js
@@ -59,19 +59,19 @@ module.exports = function (sequelize, DataTypes) {
       timestamps: false,
       indexes: [
         {
-          name: 'PRIMARY',
+          name: 'user_PRIMARY',
           unique: true,
           using: 'BTREE',
           fields: [{ name: 'ID' }],
         },
         {
-          name: 'email',
+          name: 'user_email',
           unique: true,
           using: 'BTREE',
           fields: [{ name: 'email' }],
         },
         {
-          name: 'phoneNumber',
+          name: 'user_phoneNumber',
           unique: true,
           using: 'BTREE',
           fields: [{ name: 'phoneNumber' }],

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "nodemailer": "^6.4.2",
         "passport": "^0.4.0",
         "passport-local": "^1.0.0",
+        "pg": "^8.7.3",
         "qrcode": "^1.4.0",
         "sequelize": "^6.6.5",
         "swagger-jsdoc": "^6.1.0",
@@ -1948,6 +1949,14 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    },
+    "node_modules/buffer-writer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
+      "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/buffer-xor": {
       "version": "1.0.3",
@@ -9319,6 +9328,11 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/packet-reader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
+      "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
+    },
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -9605,10 +9619,79 @@
         "node": ">=0.12"
       }
     },
+    "node_modules/pg": {
+      "version": "8.7.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.7.3.tgz",
+      "integrity": "sha512-HPmH4GH4H3AOprDJOazoIcpI49XFsHCe8xlrjHkWiapdbHK+HLtbm/GQzXYAZwmPju/kzKhjaSfMACG+8cgJcw==",
+      "dependencies": {
+        "buffer-writer": "2.0.0",
+        "packet-reader": "1.0.0",
+        "pg-connection-string": "^2.5.0",
+        "pg-pool": "^3.5.1",
+        "pg-protocol": "^1.5.0",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/pg-connection-string": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
       "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.5.1.tgz",
+      "integrity": "sha512-6iCR0wVrro6OOHFsyavV+i6KYL4lVNyYAB9RD18w66xSzN+d8b66HiwuP30Gp1SH5O9T82fckkzsRjlrhD0ioQ==",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.5.0.tgz",
+      "integrity": "sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ=="
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
     },
     "node_modules/phin": {
       "version": "2.9.3",
@@ -9743,6 +9826,41 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
       "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
       "dev": true
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/prepend-http": {
       "version": "1.0.4",
@@ -11449,6 +11567,14 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
+      "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ==",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sqlstring": {
@@ -15039,6 +15165,11 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    },
+    "buffer-writer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
+      "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw=="
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -21021,6 +21152,11 @@
         }
       }
     },
+    "packet-reader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
+      "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
+    },
     "pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -21252,10 +21388,60 @@
         "sha.js": "^2.4.8"
       }
     },
+    "pg": {
+      "version": "8.7.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.7.3.tgz",
+      "integrity": "sha512-HPmH4GH4H3AOprDJOazoIcpI49XFsHCe8xlrjHkWiapdbHK+HLtbm/GQzXYAZwmPju/kzKhjaSfMACG+8cgJcw==",
+      "requires": {
+        "buffer-writer": "2.0.0",
+        "packet-reader": "1.0.0",
+        "pg-connection-string": "^2.5.0",
+        "pg-pool": "^3.5.1",
+        "pg-protocol": "^1.5.0",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x"
+      }
+    },
     "pg-connection-string": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
       "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
+    },
+    "pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
+    },
+    "pg-pool": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.5.1.tgz",
+      "integrity": "sha512-6iCR0wVrro6OOHFsyavV+i6KYL4lVNyYAB9RD18w66xSzN+d8b66HiwuP30Gp1SH5O9T82fckkzsRjlrhD0ioQ==",
+      "requires": {}
+    },
+    "pg-protocol": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.5.0.tgz",
+      "integrity": "sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ=="
+    },
+    "pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "requires": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      }
+    },
+    "pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "requires": {
+        "split2": "^4.1.0"
+      }
     },
     "phin": {
       "version": "2.9.3",
@@ -21352,6 +21538,29 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
       "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
       "dev": true
+    },
+    "postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
+    },
+    "postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w=="
+    },
+    "postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="
+    },
+    "postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "requires": {
+        "xtend": "^4.0.0"
+      }
     },
     "prepend-http": {
       "version": "1.0.4",
@@ -22694,6 +22903,11 @@
       "requires": {
         "extend-shallow": "^3.0.0"
       }
+    },
+    "split2": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
+      "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ=="
     },
     "sqlstring": {
       "version": "2.3.2",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "nodemailer": "^6.4.2",
     "passport": "^0.4.0",
     "passport-local": "^1.0.0",
+    "pg": "^8.7.3",
     "qrcode": "^1.4.0",
     "sequelize": "^6.6.5",
     "swagger-jsdoc": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "preinstall": "rm -rf node_modules/*/.git/",
     "test": "NODE_ENV=test mocha --timeout 30000 tests/api/*.js",
     "build-dev": "sequelize db:migrate --config ./dbconfig.json --env development",
-    "build": "sequelize db:migrate --config ./dbconfig.json --env production",
+    "build": "sequelize db:migrate --config ./dbconfig.json --env production && node tests/test_supplier_produce_scan.js",
     "heroku-postbuild": "npm run bundle",
     "dev": "nodemon server.js --host 0.0.0.0",
     "start": "node server.js",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "bundle": "./node_modules/browserify/bin/cmd.js src/js/app.js | uglifyjs -mc  > src/js/bundle.js",
     "preinstall": "rm -rf node_modules/*/.git/",
     "test": "NODE_ENV=test mocha --timeout 30000 tests/api/*.js",
-    "build-dev": "sequelize db:migrate --config ./dbconfig.json --env development",
+    "build-dev": "sequelize db:migrate --config ./dbconfig.json --env development && node tests/test_supplier_produce_scan.js",
     "build": "sequelize db:migrate --config ./dbconfig.json --env production",
     "heroku-postbuild": "npm run bundle",
     "dev": "nodemon server.js --host 0.0.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "preinstall": "rm -rf node_modules/*/.git/",
     "test": "NODE_ENV=test mocha --timeout 30000 tests/api/*.js",
     "build-dev": "sequelize db:migrate --config ./dbconfig.json --env development",
-    "build": "sequelize db:migrate --config ./dbconfig.json --env production && node tests/test_supplier_produce_scan.js",
+    "build": "sequelize db:migrate --config ./dbconfig.json --env production",
     "heroku-postbuild": "npm run bundle",
     "dev": "nodemon server.js --host 0.0.0.0",
     "start": "node server.js",


### PR DESCRIPTION
* Description - Preparing to move to a Postgres database. There was an issue when we migrated to using sequelize that all database indexes were called PRIMARY. Whilst this worked on MySQL, when testing the FoodPrint web app on a Postgres DB the following error occured - Error synching models: SequelizeDatabaseError: relation "PRIMARY" already exists. Postgres indexes live in the same namespace as tables, views and sequences, so you cannot use the same name twice for any of these objects in one schema. This PR renamed the FoodPrint models indexes, installs the pg library and adds a sequelise migration script to drop the PRIMARY indexes

* Testing - 
- Site starts and DB operations are working
- Sequelise migration (`$npm run build-dev`) ran successfully and dropped PRIMARY indexes in DB
e.g. see new  indexes below for harvest and produce tables (and PRIMARY index no longer exists for each of them)
<img width="512" alt="image" src="https://user-images.githubusercontent.com/2832754/172001730-67e63ab7-36b4-4a8c-8432-d70914c03eba.png">

- Further testing required