### PR TITLE
Update tests and node scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,11 @@
     "bundle": "./node_modules/browserify/bin/cmd.js src/js/app.js | uglifyjs -mc  > src/js/bundle.js",
     "preinstall": "rm -rf node_modules/*/.git/",
     "test": "NODE_ENV=test mocha --timeout 30000 tests/api/*.js",
+    "testdb": "node tests/sequelize.js",
+    "insertproduce": "node tests/produce.js",
     "build-dev": "sequelize db:migrate --config ./dbconfig.json --env development && node tests/test_supplier_produce_scan.js",
     "build": "sequelize db:migrate --config ./dbconfig.json --env production",
-    "heroku-postbuild": "npm run bundle",
+    "heroku-postbuild": "sequelize db:migrate --config ./dbconfig.json --env production && npm run bundle",
     "dev": "nodemon server.js --host 0.0.0.0",
     "start": "node server.js",
     "format": "prettier --write 'README.md' 'server.js' 'utils/*.js' 'migrations/*.js' 'routes/*.js' 'models/*.js' 'dbxml/*.js' 'config/*.js'"

--- a/tests/produce.js
+++ b/tests/produce.js
@@ -1,4 +1,4 @@
-// node ./tests/sequelize.js
+// node ./tests/produce.js
 
 const { Op, Sequelize } = require('sequelize');
 


### PR DESCRIPTION
Description

1. As part of build process, Heroku detects both "build" and "heroku-postbuild" scripts and then only runs heroku-postbuild so the sequelize migration has been added to heroku-postbuild command.
2. Added node scripts for checking db connection and for inserting sample produce data.

Testing

- Only really tested the testdb script which was fine.