### PR TITLE
Remove current folder reference in node scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "test": "NODE_ENV=test mocha --timeout 30000 tests/api/*.js",
     "testdb": "node tests/sequelize.js",
     "insertproduce": "node tests/produce.js",
-    "build-dev": "sequelize db:migrate --config ./dbconfig.json --env development && node tests/test_supplier_produce_scan.js",
-    "build": "sequelize db:migrate --config ./dbconfig.json --env production",
-    "heroku-postbuild": "sequelize db:migrate --config ./dbconfig.json --env production && npm run bundle",
+    "build-dev": "sequelize db:migrate --config dbconfig.json --env development && node tests/test_supplier_produce_scan.js",
+    "build": "sequelize db:migrate --config dbconfig.json --env production",
+    "heroku-postbuild": "sequelize db:migrate --config dbconfig.json --env production && npm run bundle",
     "dev": "nodemon server.js --host 0.0.0.0",
     "start": "node server.js",
     "format": "prettier --write 'README.md' 'server.js' 'utils/*.js' 'migrations/*.js' 'routes/*.js' 'models/*.js' 'dbxml/*.js' 'config/*.js'"


### PR DESCRIPTION
Follow up to https://github.com/FoodPrintLabs/foodprint/pull/108 and 109. When Heroku tries to run node scripts with dot for  current location, it throws an error e.g. ERROR: Cannot find "/tmp/build_d3f936f6/filename.xyz". This should resolve that.