### PR TITLE
remove unused import

### DIFF
--- a/config/email/email.js
+++ b/config/email/email.js
@@ -2,7 +2,6 @@ const nodemailer = require('nodemailer');
 const env = process.env.NODE_ENV || 'development';
 const CUSTOM_ENUMS = require('../../utils/enums');
 const uuidv4 = require('uuid/v4');
-const { clearConfigCache } = require('prettier');
 
 var moment = require('moment'); //datetime
 var initModels = require('../../models/init-models');


### PR DESCRIPTION
Description - Prettier is used only in Development and so in a Prod environment the library is not found (in package,json it is saved as a devDependency). Heroku was throwing this error - 2022-07-02T23:04:41.262768+00:00 app[web.1]: Error: Cannot find module 'prettier'

Testing - Removed dependency and tested that email service still works and all good