### PR TITLE
file upload must be lowercase for downstream comparisons

### DIFF
--- a/routes/produce.js
+++ b/routes/produce.js
@@ -568,6 +568,9 @@ router.get('/pricepage/pdf/whatsapp', function (req, res, next) {
         let pdfFilename =
           'FoodPrint_ProducePrice_' + moment(new Date()).format('YYYY-MM-DD') + '.pdf';
 
+        // force filename to lower case so that string matching in chatbot is not an issue
+        pdfFilename = pdfFilename.toLowerCase();
+
         // stream pdf in chunks to response
         let chunks = [];
         pdfService.buildPDF(


### PR DESCRIPTION
Follow up to https://github.com/FoodPrintLabs/foodprint/pull/124. Ran into issues because Chatbot forces filename to lowercase when parsing media url and then WhatsApp queries digital ocean with lowercase filename and digital ocean responds with forbidden 403 error

Notice difference between https://fra1.digitaloceanspaces.com/foodprintweb/FoodPrint_ProducePrice_2022-07-04.pdf and https://fra1.digitaloceanspaces.com/foodprintweb/foodprint_produceprice_2022-07-04.pdf

<img width="1216" alt="image" src="https://user-images.githubusercontent.com/2832754/177220512-8500673b-6a1e-4d74-b9d0-1234389fa782.png">

response from Digital ocean when attempting to get the lowercase file
<img width="954" alt="image" src="https://user-images.githubusercontent.com/2832754/177220406-43d4ba9e-408d-40bd-ada3-04b08b5559f8.png">
