### PR TITLE
Store Twilio URL and log channel for harvests

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,16 @@ node sequelise_auto_export.js
 
 The generated models can be found in `./models`
 
+- Creating sequelize migration (which creates a js file in migrations folder and will need to be commited)
+```bash
+npx sequelize migration:create --name name_of_new_db_column
+```
+
+Run the migration
+```bash
+npx sequelize db:migrate --url ‘mysql://username:password@localhost:3306/databasename'
+```
+
 - Generate test UUID's from command line (i.e. server side).
 
 ```

--- a/models/foodprint_harvest.js
+++ b/models/foodprint_harvest.js
@@ -117,6 +117,14 @@ module.exports = function (sequelize, DataTypes) {
         type: DataTypes.STRING(255),
         allowNull: true,
       },
+    twilio_url: {
+        type: DataTypes.STRING(255),
+        allowNull: true,
+    },
+        channel: {
+            type: DataTypes.STRING(255),
+            allowNull: true,
+        },
     },
     {
       sequelize,

--- a/routes/harvest.js
+++ b/routes/harvest.js
@@ -316,8 +316,10 @@ router.post('/save/whatsapp', async function (req, res) {
   let harvest_CaptureTime = moment(new Date()).format('YYYY-MM-DD HH:mm:ss'); //time of harvest data entry
   let logdatetime = moment(new Date()).format('YYYY-MM-DD HH:mm:ss');
   let lastmodifieddatetime = moment(new Date()).format('YYYY-MM-DD HH:mm:ss');
+  let channel = 'WhatsApp';
 
   let harvest_photoHash = '';
+  let twilio_url = '';
   let host = req.get('host');
   let protocol = 'https';
 
@@ -328,6 +330,8 @@ router.post('/save/whatsapp', async function (req, res) {
 
   if (req.body.harvestURL) {
     try {
+      twilio_url = req.body.harvestURL;
+      console.log('twilio_url -' + twilio_url);
       const response = await fetch(req.body.harvestURL);
       harvest_photoHash = await response.buffer();
     } catch (e) {
@@ -351,6 +355,8 @@ router.post('/save/whatsapp', async function (req, res) {
     harvest_user: req.body.email,
     logdatetime: logdatetime,
     lastmodifieddatetime: lastmodifieddatetime,
+    twilio_url: twilio_url,
+    channel: channel,
     harvest_photoHash,
   };
   try {


### PR DESCRIPTION
* Desc - store Twilio URL for WhatsApp logs so you can query Twilio URL for content type. Twilio supports jpeg, png, gif, PDF etc but we need to store these media files on our cloud provider as Twilio will delete after 13 months.

* Testing - sql migration ran successfully. further testing required.