### PR TITLE
Simplify WhatsApp Chatbot User Registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # FoodPrint
 
 FoodPrint is a digital, blockchain-enabled, farm-to-fork (fresh produce) supply chain platform for
-smallholder farmers, primarily in developing countries. FoodPrint is designed to:
+smallholder farmers. FoodPrint is designed to:
 
 - Simplify production and harvest data collection for smallholder farmers.
 - Directly connect them to market opportunities - including but not limited to intermediaries such
@@ -38,10 +38,6 @@ intermediary. The consumer can scan a barcode associated with produce and view t
 information and supply chain stories i.e. view information on the produce they are buying, it's
 source and journey, hence from farm-to-fork. Android versions 8 & 9 and iOS versions 11 & 12 can
 automatically scan QR codes using the camera app.
-
-## Documentation
-
-TODO
 
 ## IDE Setup
 

--- a/migrations/20230421181209-email-allow-null.js
+++ b/migrations/20230421181209-email-allow-null.js
@@ -1,0 +1,17 @@
+'use strict';
+
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    await queryInterface.changeColumn('user', 'email', {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+  },
+
+  async down (queryInterface, Sequelize) {
+    await queryInterface.changeColumn('user', 'email', {
+      type: Sequelize.STRING,
+      allowNull: false,
+    });
+  }
+};

--- a/models/user.js
+++ b/models/user.js
@@ -23,7 +23,7 @@ module.exports = function (sequelize, DataTypes) {
       },
       email: {
         type: DataTypes.STRING(255),
-        allowNull: false,
+        allowNull: true,
         unique: 'email',
       },
       phoneNumber: {

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -58,9 +58,13 @@ router.post(
 
 /* Logout. */
 router.get('/logout', function (req, res) {
-  req.logout();
-  req.flash('success', 'You are now logged out.');
-  res.redirect('/app/auth/login');
+    req.logout(function(err) {
+        if (err) {
+            return next(err);
+        }
+        req.flash('success', 'You are now logged out.');
+        res.redirect('/app/auth/login');
+    });
 });
 
 /* Render Register page. */


### PR DESCRIPTION
## Description 
Make email and image fields allow null values so that WhatsApp Chatbot registration is simplified.

- to create migration - `npx sequelize migration:create --name email-allow-null`

Also fixed logout issue on Web App arising from upgrade to passport 0.6 - `req#logout requires a callback function
Error: req#logout requires a callback function`. See https://stackoverflow.com/questions/72336177/error-reqlogout-requires-a-callback-function


## Testing 

- migration tested locally by running `npm run build-dev` which gave an output of:
```
== 20230421181209-email-allow-null: migrating =======
Executing (default): ALTER TABLE `user` CHANGE `email` `email` VARCHAR(255);
Executing (default): SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE = 'BASE TABLE' AND TABLE_NAME = 'SequelizeMeta' AND TABLE_SCHEMA = 'foodprint'
Executing (default): SHOW INDEX FROM `SequelizeMeta`
Executing (default): INSERT INTO `SequelizeMeta` (`name`) VALUES (?);
== 20230421181209-email-allow-null: migrated (0.059s)
```

- tested WhatsApp registration route using Postman
<img width="1015" alt="image" src="https://user-images.githubusercontent.com/2832754/233714953-1b24bea6-e63e-45f6-9e90-0917da133893.png">

- tested logging out of web app which did not throw req#logout requires callback function error
<img width="1359" alt="image" src="https://user-images.githubusercontent.com/2832754/233715596-6fe7131d-e912-40e3-95f7-ce2263c4781d.png">
